### PR TITLE
fix: disable more rules in tests

### DIFF
--- a/packages/eslint-config/src/overrides/typescriptTests.ts
+++ b/packages/eslint-config/src/overrides/typescriptTests.ts
@@ -22,6 +22,7 @@ export const typescriptTestsOverrides = typescriptOverrides
         'consistent-return': 'error',
         '@typescript-eslint/unbound-method': 'off',
         '@typescript-eslint/no-unsafe-assignment': 'off',
+        '@typescript-eslint/no-unsafe-member-access': 'off',
       },
       env: {
         node: true,


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/eslint-config@8.1.2-canary.94.6701033798.0
  # or 
  yarn add @tablecheck/eslint-config@8.1.2-canary.94.6701033798.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
