### PR TITLE
fix: loosen eslint-config dependency version

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@emotion/eslint-plugin": "^11.11.0",
     "@nx/eslint-plugin": "^16.5.0",
-    "@tablecheck/eslint-plugin": "^4.0.0",
+    "@tablecheck/eslint-plugin": "^6.1.0",
     "@typescript-eslint/eslint-plugin": "^6.9.0",
     "@typescript-eslint/parser": "^6.9.0",
     "eslint-config-airbnb": "^19.0.4",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -40,7 +40,7 @@
     "tsimportlib": "0.0.5"
   },
   "peerDependencies": {
-    "@tablecheck/eslint-config": ">=1.8.2"
+    "@tablecheck/eslint-config": ">=8.2.0"
   },
   "devDependencies": {
     "@types/flat": "5.0.2",


### PR DESCRIPTION
Updating dependencies that were out of date.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/eslint-config@8.2.1-canary.95.6860547848.0
  npm install @tablecheck/nx@6.1.1-canary.95.6860547848.0
  # or 
  yarn add @tablecheck/eslint-config@8.2.1-canary.95.6860547848.0
  yarn add @tablecheck/nx@6.1.1-canary.95.6860547848.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
