### PR TITLE
fix(nx): quality generator should use more generic tsconfig definition

### DIFF
--- a/packages/nx/src/generators/quality/schema.json
+++ b/packages/nx/src/generators/quality/schema.json
@@ -58,6 +58,18 @@
         ]
       }
     },
+    "includeCypressComponent": {
+      "type": "boolean",
+      "description": "Does this project use Cypress Component testing?",
+      "x-prompt": "Include Cypress Component testing rules?",
+      "x-priority": "important"
+    },
+    "includeStorybook": {
+      "type": "boolean",
+      "description": "Does this project use Storybook?",
+      "x-prompt": "Include Storybook rules?",
+      "x-priority": "important"
+    },
     "svgAsComponent": {
       "type": "boolean",
       "description": "Should `import name from 'name.svg'` import a react component (using plugins/transforms) instead of an asset URL?",


### PR DESCRIPTION
Supports setting cypress component testing and storybook use independantly of the base extension setting.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/nx@6.1.3-canary.98.7162348418.0
  # or 
  yarn add @tablecheck/nx@6.1.3-canary.98.7162348418.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
