### PR TITLE
fix(nx): generators correctly respect “dry-run”

### DIFF
--- a/packages/nx/src/generators/quality/eslintConfig.ts
+++ b/packages/nx/src/generators/quality/eslintConfig.ts
@@ -4,6 +4,7 @@ import { Tree } from '@nx/devkit';
 
 import { getNxProjectRoot } from '../../utils/nx';
 import { outputPrettyFile } from '../../utils/prettier';
+import { createTempFiles } from '../../utils/tempFiles';
 
 function getExtends(
   eslintType:
@@ -58,7 +59,13 @@ export function generateEslintConfig(
   if (schema.includeStorybook) {
     ruleExtensions.push('@tablecheck/eslint-config/storybook');
   }
-  const fileContent = `
+
+  const generateFiles = createTempFiles({
+    tree,
+    projectRoot,
+    cacheLocation: __dirname,
+    createFiles: (templatePath) => {
+      const fileContent = `
 module.exports = {
     extends: [${ruleExtensions.join(',')}],
     parserOptions: {
@@ -80,5 +87,10 @@ module.exports = {
     rules: {},
 };
 `;
-  outputPrettyFile(path.join(projectRoot, '.eslintrc.cjs'), fileContent);
+      outputPrettyFile(path.join(templatePath, '.eslintrc.cjs'), fileContent);
+    },
+  });
+  generateFiles({
+    overwriteExisting: true,
+  });
 }

--- a/packages/nx/src/generators/quality/generator.ts
+++ b/packages/nx/src/generators/quality/generator.ts
@@ -1,4 +1,3 @@
-import { execSync } from 'child_process';
 import * as path from 'path';
 
 import {
@@ -58,14 +57,11 @@ export async function qualityGenerator(
     {},
   );
   generateEslintConfig(tree, schema);
-  execSync('npx husky install', {
-    cwd: process.cwd(),
-    stdio: 'inherit',
-  });
   generateConfig(tree, schema);
   generateIcons(tree, schema);
   await generateFileTypes(tree, schema);
   await formatFiles(tree);
+  console.log('Run `npx husky install` to install git hooks');
 }
 
 export default qualityGenerator;

--- a/packages/nx/src/generators/ts-carbon-icons/generator.ts
+++ b/packages/nx/src/generators/ts-carbon-icons/generator.ts
@@ -5,6 +5,7 @@ import { Tree } from '@nx/devkit';
 import { getNxProjectRoot } from '../../utils/nx';
 import { detectInstalledVersion } from '../../utils/packageJson';
 import { outputPrettyFile } from '../../utils/prettier';
+import { createTempFiles } from '../../utils/tempFiles';
 
 export function tsCarbonIconsGenerator(
   tree: Tree,
@@ -29,27 +30,50 @@ export function tsCarbonIconsGenerator(
         '11',
       );
     }
-    // eslint-disable-next-line @typescript-eslint/no-var-requires -- await import throws segfault errors as this is common Js
-    const carbonIcons = require(
-      path.join(carbonPackageJsonPath, '..'),
-    ) as Record<string, never>;
-    const fileContent = `${Object.keys(carbonIcons).reduce(
-      (result, iconName) =>
-        `${result}  declare export const ${iconName}: CarbonIcon;\n`,
-      `// this file is generated with \`nx generate @tablecheck/nx:ts-carbon-icons ${schema.project}\`
-      declare module '@carbon/icons-react' {
-        declare export type CarbonIconSize = 16 | 20 | 24 | 32;
-        declare export type CarbonIcon = React.ForwardRefExoticComponent<
-          {
-            size?: CarbonIconSize | \`\${CarbonIconSize}\` | (string & {}) | (number & {});
-          } & React.RefAttributes<SVGSVGElement>
-        >;
-    `,
-    )}\n}`;
-    outputPrettyFile(
-      path.join(projectSourceRoot, 'definitions', 'carbonIcons.gen.d.ts'),
-      fileContent,
-    );
+    const carbonVersion =
+      // eslint-disable-next-line @typescript-eslint/no-var-requires -- await import throws segfault errors as this is common Js
+      (require(carbonPackageJsonPath) as { version: string }).version;
+    const cacheContent = `@carbon/icons-react@${carbonVersion}\n${projectSourceRoot}`;
+    const relativeSourcePath = path.relative(projectRoot, projectSourceRoot);
+
+    const generateFiles = createTempFiles({
+      tree,
+      projectRoot,
+      cacheContent,
+      cacheLocation: __dirname,
+      createFiles: (templatePath) => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires -- await import throws segfault errors as this is common Js
+        const carbonIcons = require(
+          path.join(carbonPackageJsonPath, '..'),
+        ) as Record<string, never>;
+        outputPrettyFile(
+          path.join(
+            templatePath,
+            relativeSourcePath,
+            'definitions',
+            'carbonIcons.gen.d.ts',
+          ),
+          `// this file is generated with \`nx generate @tablecheck/nx:ts-carbon-icons ${
+            schema.project
+          }\`
+declare module '@carbon/icons-react' {
+  declare export type CarbonIconSize = 16 | 20 | 24 | 32;
+  declare export type CarbonIcon = React.ForwardRefExoticComponent<
+    {
+      size?: CarbonIconSize | \`\${CarbonIconSize}\` | (string & {}) | (number & {});
+    } & React.RefAttributes<SVGSVGElement>
+  >;
+${Object.keys(carbonIcons)
+  .map((iconName) => `  declare export const ${iconName}: CarbonIcon;`)
+  .join('\n')}
+}`,
+        );
+      },
+    });
+
+    generateFiles({
+      overwriteExisting: true,
+    });
   } catch (e) {
     console.warn(e);
   }

--- a/packages/nx/src/utils/tempFiles.ts
+++ b/packages/nx/src/utils/tempFiles.ts
@@ -1,0 +1,44 @@
+import * as path from 'path';
+
+import { Tree, generateFiles } from '@nx/devkit';
+import fs from 'fs-extra';
+
+type GenerateFilesFunction = (
+  substitutions: Parameters<typeof generateFiles>[3],
+) => void;
+
+export function createTempFiles({
+  tree,
+  projectRoot,
+  cacheContent,
+  cacheLocation,
+  createFiles,
+}: {
+  tree: Tree;
+  projectRoot: string;
+  cacheContent?: string;
+  cacheLocation: string;
+  createFiles: (templatePath: string) => void;
+}): GenerateFilesFunction {
+  const cachePath = path.join(cacheLocation, '.cache');
+  const templatePath = path.join(cacheLocation, 'files');
+  const generateFunction: GenerateFilesFunction = (substitutions) =>
+    generateFiles(
+      tree,
+      templatePath,
+      path.relative(tree.root, projectRoot),
+      substitutions,
+    );
+  if (cacheContent) {
+    if (fs.existsSync(cachePath)) {
+      const cache = fs.readFileSync(cachePath, 'utf-8');
+      if (cache === cacheContent) {
+        return generateFunction;
+      }
+    }
+    fs.writeFileSync(cachePath, cacheContent);
+  }
+  fs.emptyDirSync(templatePath);
+  createFiles(templatePath);
+  return generateFunction;
+}


### PR DESCRIPTION
Without this change we would write the files even in dry-mode. This meant that the “preview” of the generate UI would change files!!
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/nx@6.1.3-canary.99.7205549679.0
  # or 
  yarn add @tablecheck/nx@6.1.3-canary.99.7205549679.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
