### PR TITLE
fix(nx): eslint config generation should use relative paths

### DIFF
--- a/auditjs.json
+++ b/auditjs.json
@@ -1308,6 +1308,38 @@
           "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2023-46234?component-type=npm&component-name=browserify-sign&utm_source=auditjs&utm_medium=integration&utm_content=4.0.41"
         }
       ]
+    },
+    {
+      "coordinates": "pkg:npm/vite@4.4.9",
+      "description": "[![npm][npm-img]][npm-url] [![node][node-img]][node-url] [![unix CI status][unix-ci-img]][unix-ci-url] [![windows CI status][windows-ci-img]][windows-ci-url]",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/vite@4.4.9?utm_source=auditjs&utm_medium=integration&utm_content=4.0.41",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2023-49293",
+          "title": "[CVE-2023-49293] CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+          "description": "Vite is a website frontend framework. When Vite's HTML transformation is invoked manually via `server.transformIndexHtml`, the original request URL is passed in unmodified, and the `html` being transformed contains inline module scripts (`<script type=\"module\">...</script>`), it is possible to inject arbitrary HTML into the transformed output by supplying a malicious URL query string to `server.transformIndexHtml`. Only apps using `appType: 'custom'` and using the default Vite HTML middleware are affected. The HTML entry must also contain an inline script. The attack requires a user to click on a malicious URL while running the dev server. Restricted files aren't exposed to the attacker. This issue has been addressed in vite@5.0.5, vite@4.5.1, and vite@4.4.12. There are no known workarounds for this vulnerability.",
+          "cvssScore": 6.1,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+          "cve": "CVE-2023-49293",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2023-49293?component-type=npm&component-name=vite&utm_source=auditjs&utm_medium=integration&utm_content=4.0.41"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/vite@4.4.1",
+      "description": "[![npm][npm-img]][npm-url] [![node][node-img]][node-url] [![unix CI status][unix-ci-img]][unix-ci-url] [![windows CI status][windows-ci-img]][windows-ci-url]",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/vite@4.4.1?utm_source=auditjs&utm_medium=integration&utm_content=4.0.41",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2023-49293",
+          "title": "[CVE-2023-49293] CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+          "description": "Vite is a website frontend framework. When Vite's HTML transformation is invoked manually via `server.transformIndexHtml`, the original request URL is passed in unmodified, and the `html` being transformed contains inline module scripts (`<script type=\"module\">...</script>`), it is possible to inject arbitrary HTML into the transformed output by supplying a malicious URL query string to `server.transformIndexHtml`. Only apps using `appType: 'custom'` and using the default Vite HTML middleware are affected. The HTML entry must also contain an inline script. The attack requires a user to click on a malicious URL while running the dev server. Restricted files aren't exposed to the attacker. This issue has been addressed in vite@5.0.5, vite@4.5.1, and vite@4.4.12. There are no known workarounds for this vulnerability.",
+          "cvssScore": 6.1,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+          "cve": "CVE-2023-49293",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2023-49293?component-type=npm&component-name=vite&utm_source=auditjs&utm_medium=integration&utm_content=4.0.41"
+        }
+      ]
     }
   ],
   "ignore": [
@@ -1541,6 +1573,9 @@
     },
     {
       "id": "CVE-2023-46234"
+    },
+    {
+      "id": "CVE-2023-49293"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2509,6 +2509,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -19397,9 +19398,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "funding": [
         {
           "type": "individual",

--- a/packages/nx/src/generators/quality/eslintConfig.ts
+++ b/packages/nx/src/generators/quality/eslintConfig.ts
@@ -52,6 +52,7 @@ export function generateEslintConfig(
 ) {
   const projectName = schema.project;
   const { projectRoot } = getNxProjectRoot(tree, projectName);
+  const relativeProjectRoot = path.relative(tree.root, projectRoot);
   const ruleExtensions = getExtends(schema.eslintType);
   if (schema.includeCypressComponent) {
     ruleExtensions.push('@tablecheck/eslint-config/component');
@@ -67,19 +68,19 @@ export function generateEslintConfig(
     createFiles: (templatePath) => {
       const fileContent = `
 module.exports = {
-    extends: [${ruleExtensions.join(',')}],
+    extends: [${ruleExtensions.map((r) => `'${r}'`).join(',')}],
     parserOptions: {
         project: [
-          '${projectRoot}/tsconfig.json',
-          '${projectRoot}/tsconfig.*?.json',
+          '${relativeProjectRoot}/tsconfig.json',
+          '${relativeProjectRoot}/tsconfig.*?.json',
         ],
     },
     settings: {
       'import/resolver': {
           typescript: {
               project: [
-                '${projectRoot}/tsconfig.json',
-                '${projectRoot}/tsconfig.*?.json',
+                '${relativeProjectRoot}/tsconfig.json',
+                '${relativeProjectRoot}/tsconfig.*?.json',
               ],
             },
         },


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/nx@6.1.4-canary.100.7485085795.0
  # or 
  yarn add @tablecheck/nx@6.1.4-canary.100.7485085795.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
