### PR TITLE
fix: handle prettier formatting of certain json files

### DIFF
--- a/packages/prettier-config/config.json
+++ b/packages/prettier-config/config.json
@@ -8,6 +8,17 @@
       "options": {
         "singleQuote": false
       }
+    },
+    {
+      "files": [
+        "devcontainer.json",
+        "jsconfig.json",
+        "language-configuration.json",
+        "tsconfig.json"
+      ],
+      "options": {
+        "parser": "json"
+      }
     }
   ]
 }


### PR DESCRIPTION
This is a safety config for an issue introduced in prettier 3.2.2

See https://github.com/prettier/prettier/issues/15956#issuecomment-1905768038
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/prettier-config@4.0.1-canary.101.7664911459.0
  # or 
  yarn add @tablecheck/prettier-config@4.0.1-canary.101.7664911459.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
