### PR TITLE
fix: disable @typescript-eslint/no-unsafe-assignment where any is allowed

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
     "prepare": "husky install && npm run build:ci",
     "all-upgrade": "npm-upgrade && lerna exec --concurrency 1 -- npm-upgrade"
   },
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "devDependencies": {
     "@auto-it/all-contributors": "11.0.4",
     "@auto-it/first-time-contributor": "11.0.4",

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -17,10 +17,7 @@
   "bin": {
     "tablecheck-frontend-audit": "bin/main.js"
   },
-  "files": [
-    "bin",
-    "dist"
-  ],
+  "files": ["bin", "dist"],
   "scripts": {
     "build": "tsc -p ./tsconfig.build.json",
     "prepublish": "npm run build"

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -13,9 +13,7 @@
     "./formatters/junit": "./formatters/junit.js"
   },
   "main": "index.js",
-  "files": [
-    "formatters"
-  ],
+  "files": ["formatters"],
   "dependencies": {
     "@commitlint/config-conventional": "^17",
     "junit-report-builder": "3.0.1"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -53,9 +53,7 @@
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "dependencies": {
     "@emotion/eslint-plugin": "^11.11.0",
     "@nx/eslint-plugin": "^16.5.0",

--- a/packages/eslint-config/src/overrides/cypress.ts
+++ b/packages/eslint-config/src/overrides/cypress.ts
@@ -29,6 +29,7 @@ export const cypressOverrides: Linter.ConfigOverride | undefined =
           'promise/always-return': 'off',
           'import/no-import-module-exports': 'off',
           '@typescript-eslint/no-explicit-any': 'off',
+          '@typescript-eslint/no-unsafe-assignment': 'off',
           '@typescript-eslint/no-namespace': 'off',
           '@typescript-eslint/naming-convention': (
             ['error'] as Linter.RuleLevelAndOptions

--- a/packages/eslint-config/src/overrides/storybook.ts
+++ b/packages/eslint-config/src/overrides/storybook.ts
@@ -20,6 +20,7 @@ export const storybookOverrides: Linter.ConfigOverride = {
     'react/require-default-props': 'off',
     'react-refresh/only-export-components': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unsafe-assignment': 'off',
     '@typescript-eslint/naming-convention': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
     'consistent-return': 'error',

--- a/packages/eslint-config/src/overrides/typescriptDocumentation.ts
+++ b/packages/eslint-config/src/overrides/typescriptDocumentation.ts
@@ -17,6 +17,7 @@ export const typescriptDocumentationOverrides = mergeDeep(
     rules: {
       ...documentationOverrides.rules,
       '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/naming-convention': 'off',
       '@typescript-eslint/ban-ts-comment': 'off',
       // here we use the more lenient consistent-return to help prevent weird errors

--- a/packages/eslint-config/src/presets/cypressInternal.ts
+++ b/packages/eslint-config/src/presets/cypressInternal.ts
@@ -25,6 +25,7 @@ export const cypressPreset = {
     'promise/always-return': 'off',
     'import/no-import-module-exports': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unsafe-assignment': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/naming-convention': (
       ['error'] as Linter.RuleLevelAndOptions

--- a/packages/eslint-config/src/presets/typescript.ts
+++ b/packages/eslint-config/src/presets/typescript.ts
@@ -35,6 +35,7 @@ module.exports = {
         '@typescript-eslint/no-empty-interface': 'warn',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-unsafe-assignment': 'off',
       },
     }),
     buildBaseTypescript({

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -15,9 +15,7 @@
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsc -p ./tsconfig.build.json"
   },

--- a/packages/semantic-release-config/package.json
+++ b/packages/semantic-release-config/package.json
@@ -9,10 +9,7 @@
   },
   "version": "7.0.0",
   "main": "index.js",
-  "files": [
-    "with-npm-publish/package.json",
-    "withNpmPublish.js"
-  ],
+  "files": ["with-npm-publish/package.json", "withNpmPublish.js"],
   "dependencies": {
     "@semantic-release/commit-analyzer": "^9.0.2",
     "@semantic-release/exec": "^6.0.3",


### PR DESCRIPTION
```ts
const a: any;
const b = a; // throws eslint error
```

In this scenario, usually we should avoid this. In the case of tests, typescript definition files and storybook, we allow `any` so it makes sense to turn off this rule.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/frontend-audit@6.0.1-canary.104.7707943839.0
  npm install @tablecheck/commitlint-config@6.0.1-canary.104.7707943839.0
  npm install @tablecheck/eslint-config@8.2.5-canary.104.7707943839.0
  npm install @tablecheck/eslint-plugin@6.1.2-canary.104.7707943839.0
  npm install @tablecheck/semantic-release-config@7.0.1-canary.104.7707943839.0
  # or 
  yarn add @tablecheck/frontend-audit@6.0.1-canary.104.7707943839.0
  yarn add @tablecheck/commitlint-config@6.0.1-canary.104.7707943839.0
  yarn add @tablecheck/eslint-config@8.2.5-canary.104.7707943839.0
  yarn add @tablecheck/eslint-plugin@6.1.2-canary.104.7707943839.0
  yarn add @tablecheck/semantic-release-config@7.0.1-canary.104.7707943839.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
