### PR TITLE
fix(commitlint-config): junit formatter updated to include top level title

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2509,6 +2509,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -23616,9 +23617,9 @@
       }
     },
     "node_modules/junit-report-builder": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/junit-report-builder/-/junit-report-builder-3.0.1.tgz",
-      "integrity": "sha512-B8AZ2q24iGwPM3j/ZHc9nD0BY1rKhcnWCA1UvT8mhHfR8Vo/HTtg3ojMyo55BgctqQGZG7H8z0+g+mEUc32jgg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/junit-report-builder/-/junit-report-builder-3.2.1.tgz",
+      "integrity": "sha512-IMCp5XyDQ4YESDE4Za7im3buM0/7cMnRfe17k2X8B05FnUl9vqnaliX6cgOEmPIeWKfJrEe/gANRq/XgqttCqQ==",
       "dependencies": {
         "date-format": "4.0.3",
         "lodash": "^4.17.21",
@@ -37551,7 +37552,7 @@
       "license": "MIT",
       "dependencies": {
         "@commitlint/config-conventional": "^17",
-        "junit-report-builder": "3.0.1"
+        "junit-report-builder": "3.2.1"
       },
       "engines": {
         "node": ">= 16.16.0"

--- a/packages/commitlint-config/formatters/junit.js
+++ b/packages/commitlint-config/formatters/junit.js
@@ -5,6 +5,12 @@
 
 const builder = require('junit-report-builder');
 
+const levelMap = {
+  [0]: 'Disabled',
+  [1]: 'Warning',
+  [2]: 'Error',
+};
+
 /**
  * Format the commitlint report as a valid JUnit XML report.
  *
@@ -19,19 +25,21 @@ function formatJunit(report = {}) {
     const errorCount = result.errors?.length || 0;
     const warningCount = result.warnings?.length || 0;
     const suite = builder.testSuite().name(result.input);
-    suite.property('errors', errorCount);
-    suite.property('failures', errorCount + warningCount);
-    suite.property('tests', Math.max(errorCount + warningCount, 1));
-    suite.property('skipped', 0);
 
     result.errors?.forEach((error) => {
-      const testcase = suite.testCase().className('error').name(error.name);
-      testcase.failure('error').standardOutput(error.message);
+      suite
+        .testCase()
+        .name(error.name)
+        .className(levelMap[error.level])
+        .error(error.message);
     });
 
     result.warnings?.forEach((warning) => {
-      const testcase = suite.testCase().className('warning').name(warning.name);
-      testcase.failure('warning').standardOutput(warning.message);
+      suite
+        .testCase()
+        .name(warning.name)
+        .className(levelMap[warning.level])
+        .failure(warning.message);
     });
 
     if (errorCount + warningCount === 0) {
@@ -39,7 +47,7 @@ function formatJunit(report = {}) {
     }
   });
 
-  return builder.build();
+  return builder.name('Commit Lint').build();
 }
 
 module.exports = formatJunit;

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -16,7 +16,7 @@
   "files": ["formatters"],
   "dependencies": {
     "@commitlint/config-conventional": "^17",
-    "junit-report-builder": "3.0.1"
+    "junit-report-builder": "3.2.1"
   },
   "peerDependencies": {
     "@commitlint/cli": "^17"


### PR DESCRIPTION
Moving changes from https://github.com/davidparsson/junit-report-builder/pull/61

Sample output:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="Commit Lint" tests="2" failures="0" errors="2" skipped="0">
  <testsuite name="some bad commit" tests="2" failures="0" errors="2" skipped="0">
    <testcase name="subject-empty" classname="Error">
      <error message="subject may not be empty"/>
    </testcase>
    <testcase name="type-empty" classname="Error">
      <error message="type may not be empty"/>
    </testcase>
  </testsuite>
</testsuites>
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/commitlint-config@6.0.2-canary.105.7750623779.0
  # or 
  yarn add @tablecheck/commitlint-config@6.0.2-canary.105.7750623779.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
