### PR TITLE
fix: add method signature style error

### DIFF
--- a/packages/audit/project.json
+++ b/packages/audit/project.json
@@ -9,14 +9,11 @@
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": ["packages/audit/**/*.ts"]
-      }
-    },
-    "quality:format": {
-      "executor": "@tablecheck/nx:quality",
-      "outputs": ["{options.outputFile}"],
-      "options": {
-        "lintFilePatterns": ["packages/audit/**/*.ts"],
-        "fix": true
+      },
+      "configurations": {
+        "format": {
+          "fix": true
+        }
       }
     }
   },

--- a/packages/commitlint-config/project.json
+++ b/packages/commitlint-config/project.json
@@ -9,13 +9,11 @@
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": ["packages/commitlint-config/index.js"]
-      }
-    },
-    "quality:format": {
-      "executor": "@tablecheck/nx:quality",
-      "options": {
-        "lintFilePatterns": ["packages/commitlint-config/index.js"],
-        "fix": true
+      },
+      "configurations": {
+        "format": {
+          "fix": true
+        }
       }
     }
   },

--- a/packages/eslint-config/project.json
+++ b/packages/eslint-config/project.json
@@ -29,13 +29,11 @@
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": ["packages/eslint-config/**/*.ts"]
-      }
-    },
-    "quality:format": {
-      "executor": "@tablecheck/nx:quality",
-      "options": {
-        "lintFilePatterns": ["packages/eslint-config/**/*.ts"],
-        "fix": true
+      },
+      "configurations": {
+        "format": {
+          "fix": true
+        }
       }
     }
   },

--- a/packages/eslint-config/src/overrides/buildBaseTypescript.ts
+++ b/packages/eslint-config/src/overrides/buildBaseTypescript.ts
@@ -28,6 +28,7 @@ export const baseTypescriptRules: Linter.RulesRecord = {
 
   '@typescript-eslint/no-explicit-any': 'error',
   '@typescript-eslint/no-unsafe-enum-comparison': 'off',
+  '@typescript-eslint/method-signature-style': 'error',
   '@typescript-eslint/prefer-nullish-coalescing': [
     'error',
     {

--- a/packages/eslint-plugin/project.json
+++ b/packages/eslint-plugin/project.json
@@ -9,14 +9,11 @@
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": ["packages/eslint-plugin/**/*.ts"]
-      }
-    },
-    "quality:format": {
-      "executor": "@tablecheck/nx:quality",
-      "outputs": ["{options.outputFile}"],
-      "options": {
-        "lintFilePatterns": ["packages/eslint-plugin/**/*.ts"],
-        "fix": true
+      },
+      "configurations": {
+        "format": {
+          "fix": true
+        }
       }
     },
     "quality:docs": {

--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -17,22 +17,11 @@
           "packages/nx/generators.json",
           "packages/nx/migrations.json"
         ]
-      }
-    },
-    "quality:format": {
-      "executor": "@tablecheck/nx:quality",
-      "outputs": ["{options.outputFile}"],
-      "options": {
-        "lintFilePatterns": [
-          "packages/nx/src/*.ts",
-          "packages/nx/src/*/*.ts",
-          "packages/nx/src/*/*/*.ts",
-          "packages/nx/executors.json",
-          "packages/nx/package.json",
-          "packages/nx/generators.json",
-          "packages/nx/migrations.json"
-        ],
-        "fix": true
+      },
+      "configurations": {
+        "format": {
+          "fix": true
+        }
       }
     }
   },

--- a/packages/nx/src/generators/quality/projectConfig.ts
+++ b/packages/nx/src/generators/quality/projectConfig.ts
@@ -27,12 +27,12 @@ export function updateProjectConfig(tree: Tree, projectName: string) {
           ),
       ),
     },
-  };
-  const lintFormatTarget = merge({}, lintTarget, {
-    options: {
-      fix: true,
+    configurations: {
+      format: {
+        fix: true,
+      },
     },
-  });
+  };
   try {
     const projectConfig = readProjectConfiguration(tree, projectName);
     updateProjectConfiguration(
@@ -41,7 +41,6 @@ export function updateProjectConfig(tree: Tree, projectName: string) {
       merge(projectConfig, {
         targets: {
           quality: lintTarget,
-          'quality:format': lintFormatTarget,
         },
       }),
     );
@@ -55,7 +54,6 @@ export function updateProjectConfig(tree: Tree, projectName: string) {
       sourceRoot: 'src',
       targets: {
         quality: lintTarget,
-        'quality:format': lintFormatTarget,
       },
     });
   }

--- a/packages/semantic-release-config/project.json
+++ b/packages/semantic-release-config/project.json
@@ -9,14 +9,11 @@
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": ["packages/semantic-release-config/index.js"]
-      }
-    },
-    "quality:format": {
-      "executor": "@tablecheck/nx:quality",
-      "outputs": ["{options.outputFile}"],
-      "options": {
-        "lintFilePatterns": ["packages/semantic-release-config/index.js"],
-        "fix": true
+      },
+      "configurations": {
+        "format": {
+          "fix": true
+        }
       }
     }
   },


### PR DESCRIPTION
See https://www.totaltypescript.com/method-shorthand-syntax-considered-harmful
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/frontend-audit@6.1.0-canary.106.7795884210.0
  npm install @tablecheck/commitlint-config@6.1.0-canary.106.7795884210.0
  npm install @tablecheck/eslint-config@8.3.0-canary.106.7795884210.0
  npm install @tablecheck/eslint-plugin@6.2.0-canary.106.7795884210.0
  npm install @tablecheck/nx@6.2.0-canary.106.7795884210.0
  npm install @tablecheck/semantic-release-config@7.1.0-canary.106.7795884210.0
  # or 
  yarn add @tablecheck/frontend-audit@6.1.0-canary.106.7795884210.0
  yarn add @tablecheck/commitlint-config@6.1.0-canary.106.7795884210.0
  yarn add @tablecheck/eslint-config@8.3.0-canary.106.7795884210.0
  yarn add @tablecheck/eslint-plugin@6.2.0-canary.106.7795884210.0
  yarn add @tablecheck/nx@6.2.0-canary.106.7795884210.0
  yarn add @tablecheck/semantic-release-config@7.1.0-canary.106.7795884210.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
