### PR TITLE
feat: allow `_destroy` as a property

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ dist
 .prettierignore
 styleguide
 CHANGELOG.md
+.all-contributorsrc

--- a/packages/eslint-config/src/rules/namingConvention.ts
+++ b/packages/eslint-config/src/rules/namingConvention.ts
@@ -113,6 +113,15 @@ export const namingRules: Linter.RulesRecord = {
     },
     {
       selector: ['property', 'parameterProperty'],
+      format: null,
+      types: ['boolean'],
+      filter: {
+        regex: '^_destroy(_|$)', // `_destroy` and `_destroy_*` is used in monolith APIs as a convention
+        match: true,
+      },
+    },
+    {
+      selector: ['property', 'parameterProperty'],
       format: ['camelCase', 'PascalCase', 'snake_case', 'UPPER_CASE'],
       leadingUnderscore: 'allowDouble', // double for __html
     },

--- a/packages/eslint-config/tests/namingConvention.ts/variables.tsx
+++ b/packages/eslint-config/tests/namingConvention.ts/variables.tsx
@@ -11,3 +11,12 @@ function SomeComponent({ icon: Icon, command }) {
   const { other: Other } = command;
   const iconComponentRef = null;
 }
+
+/** _destroy: true special property */
+saveValue({ id: 'id', _destroy: true });
+cy.wait('@monolithSettings_PUT_/sections/1')
+  .its('request.body')
+  .should('deep.equal', {
+    name: 'section 1',
+    _destroy_background_image: true,
+  });


### PR DESCRIPTION
The `_destroy: true` property is used as a special key in monolith/ruby-on-rails APIs to indicate that the sub-record should be destroyed so we should allow this specific exception.

We have a _ton_ of "eslint-disable" comments related to this in our repos.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/eslint-config@8.5.0-canary.108.8504387473.0
  # or 
  yarn add @tablecheck/eslint-config@8.5.0-canary.108.8504387473.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
