### PR TITLE
feat: add react rule for no leaked rendering

### DIFF
--- a/packages/eslint-config/src/rules/react.ts
+++ b/packages/eslint-config/src/rules/react.ts
@@ -61,7 +61,7 @@ export const reactRules: Linter.RulesRecord = {
       warnOnDuplicates: true,
     },
   ],
-
+  'react/jsx-no-leaked-render': ['error', { validStrategies: ['ternary'] }],
   '@tablecheck/consistent-react-import': 'error',
   'react-refresh/only-export-components': [
     'warn',


### PR DESCRIPTION
There's a auto-fixable rule for this "footgun", so we should enable it seeing as it already exists.

See;
* https://stackoverflow.com/a/65713598
* https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-leaked-render.md
* https://kentcdodds.com/blog/use-ternaries-rather-than-and-and-in-jsx
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/eslint-config@9.0.1-canary.111.10052710064.0
  # or 
  yarn add @tablecheck/eslint-config@9.0.1-canary.111.10052710064.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
