### PR TITLE
fix(eslint-plugin): shortest import sometimes falsely tried to use re…

### DIFF
--- a/packages/eslint-plugin/__tests__/fixtures/tsconfig.base_root.json
+++ b/packages/eslint-plugin/__tests__/fixtures/tsconfig.base_root.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "~/*": ["./test_src/*"]
+    }
+  },
+  "include": ["test_src/**/*.ts", "test_src/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/packages/eslint-plugin/src/shortestImport.ts
+++ b/packages/eslint-plugin/src/shortestImport.ts
@@ -33,9 +33,8 @@ class RuleChecker {
 
   constructor(compilerOptions: CompilerOptions) {
     const { baseUrl, pathsBasePath, rootDir, rootDirs } = compilerOptions;
-
     this.baseUrl = baseUrl;
-    this.pathsBasePath = pathsBasePath;
+    this.pathsBasePath = pathsBasePath ?? baseUrl;
     this.rootDir = rootDir;
     this.rootDirs = rootDirs;
     this.compilerPaths = this.composeCompilerPaths(compilerOptions.paths);
@@ -172,10 +171,8 @@ class RuleChecker {
     if (importPath.startsWith('@') || importPath === '.') return true;
     const isPathMapping = Object.keys(this.allPaths).some(
       (key) =>
-        importPath.startsWith(key) ||
-        importPath.startsWith(key.replace(/\/$/, '')),
+        importPath.startsWith(key) || importPath === key.replace(/\/$/, ''),
     );
-
     if (isPathMapping) return false;
     return !importPath.startsWith('.') && !importPath.startsWith('/');
   }


### PR DESCRIPTION
…lative paths

Example case was when a `junit/` folder existed and `junit-report-builder` was added in, causing the detection algorithm for paths to fail.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/eslint-config@9.2.1-canary.113.10659249351.0
  npm install @tablecheck/eslint-plugin@7.1.1-canary.113.10659249351.0
  # or 
  yarn add @tablecheck/eslint-config@9.2.1-canary.113.10659249351.0
  yarn add @tablecheck/eslint-plugin@7.1.1-canary.113.10659249351.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
