### PR TITLE
feat: adds support for non-default exported import remapping

### DIFF
--- a/packages/vite-import-massager-plugin/src/index.spec.ts
+++ b/packages/vite-import-massager-plugin/src/index.spec.ts
@@ -176,6 +176,64 @@ describe('other tests', () => {
     );
   });
 
+  it('should support non-default exports', () => {
+    plugin = new ImportMassagingPlugin([
+      {
+        packageName: '@tablecheck/tablekit-react',
+        importTransform: (importName) => `/es/${importName}.js`,
+        exportTransform: (exportName) => `{ ${exportName} }`,
+      },
+    ]);
+    const { code } = plugin.transform(
+      `import { Text } from "@tablecheck/tablekit-react";`,
+      'src/index.js',
+    );
+    expect(code).toMatchInlineSnapshot(
+      `"import { Text } from "@tablecheck/tablekit-react/es/Text.js";"`,
+    );
+  });
+
+  it('should support non-default alias exports', () => {
+    plugin = new ImportMassagingPlugin([
+      {
+        packageName: '@tablecheck/tablekit-react',
+        importTransform: (importName) => `/es/${importName}.js`,
+        exportTransform: (exportName, alias) =>
+          alias ? `{ ${exportName} as ${alias} }` : `{ ${exportName} }`,
+      },
+    ]);
+    const { code } = plugin.transform(
+      `import { Text as T2 } from "@tablecheck/tablekit-react";`,
+      'src/index.js',
+    );
+    expect(code).toMatchInlineSnapshot(
+      `"import { Text as T2 } from "@tablecheck/tablekit-react/es/Text.js";"`,
+    );
+  });
+
+  it('should handle real-world non-default exports', () => {
+    plugin = new ImportMassagingPlugin([
+      {
+        packageName: '@tablecheck/tablekit-react',
+        importTransform: (importName) => `/es/${importName}.js`,
+        exportTransform: (exportName, alias) =>
+          alias ? `{ ${exportName} as ${alias} }` : `{ ${exportName} }`,
+      },
+    ]);
+    const { code } = plugin.transform(
+      `import {
+  Button,
+  IconButton,
+  TabContent,
+  Tabs as TablekitTabs,
+} from "@tablecheck/tablekit-react";`,
+      'src/index.js',
+    );
+    expect(code).toMatchInlineSnapshot(
+      `"import { Button } from "@tablecheck/tablekit-react/es/Button.js";import { IconButton } from "@tablecheck/tablekit-react/es/IconButton.js";import { TabContent } from "@tablecheck/tablekit-react/es/TabContent.js";import { Tabs as TablekitTabs } from "@tablecheck/tablekit-react/es/Tabs.js";"`,
+    );
+  });
+
   it('should not transform node_modules', () => {
     plugin = new ImportMassagingPlugin([
       {


### PR DESCRIPTION
This to support fixing our TableKit exports.

```ts
new ImportMassagerPlugin([
          {
            packageName: '@tablecheck/tablekit-react',
            importTransform: (importName) => {
              const importPath = tablekitEsmMap.get(importName);
              if (importPath) return importPath;
              const defaultImportPath = tablekitEsmMap.get('default');

              const startsWithKey = tablekitEsmMapKeys.find(
                (k) =>
                  importName.toLowerCase().startsWith(k.toLowerCase()) ||
                  `Variant${k}` === importName,
              );
              if (startsWithKey)
                return (
                  tablekitEsmMap.get(startsWithKey) ??
                  defaultImportPath ??
                  importName
                );
              return defaultImportPath ?? `/${importName}`;
            },
            exportTransform: (exportName, alias) =>
              alias ? `{${exportName} as ${alias}}` : `{ ${exportName} }`,
          },
          {
            transformPackages: ['@tablecheck'],
            packageName: '@tablecheck/tablekit-core',
            importTransform: getTkCoreImportPath,
            exportTransform: (exportName, alias) => {
              const importPath = getTkCoreImportPath(exportName);
              if (importPath.includes('/components/'))
                return `* as ${alias || exportName}`;
              return alias
                ? `{${exportName} as ${alias}}`
                : `{ ${exportName} }`;
            },
          },
        ])
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/vite-import-massager-plugin@2.1.0-canary.115.10897675676.0
  # or 
  yarn add @tablecheck/vite-import-massager-plugin@2.1.0-canary.115.10897675676.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
