### PR TITLE
feat(eslint-config): add ts rule to enforce member accessibility in classes

### DIFF
--- a/packages/eslint-config/src/overrides/buildBaseTypescript.ts
+++ b/packages/eslint-config/src/overrides/buildBaseTypescript.ts
@@ -48,6 +48,15 @@ export const baseTypescriptRules: Linter.RulesRecord = {
     },
   ],
   '@tablecheck/prefer-shortest-import': 'error',
+  '@typescript-eslint/explicit-member-accessibility': [
+    'error',
+    {
+      accessibility: 'explicit',
+      overrides: {
+        constructors: 'no-public',
+      },
+    },
+  ],
 };
 
 export function buildBaseTypescript<T extends Linter.RulesRecord>({


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/eslint-config@10.1.0-canary.116.11452183036.0
  # or 
  yarn add @tablecheck/eslint-config@10.1.0-canary.116.11452183036.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
