### PR TITLE
fix: bump eslint-config-airbnb-typescript to 18.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17564,17 +17564,16 @@
       }
     },
     "node_modules/eslint-config-airbnb-typescript": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-17.1.0.tgz",
-      "integrity": "sha512-GPxI5URre6dDpJ0CtcthSZVBAfI+Uw7un5OYNVxP2EYi3H81Jw701yFP7AU+/vCE7xBtFmjge7kfhhk4+RAiig==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-18.0.0.tgz",
+      "integrity": "sha512-oc+Lxzgzsu8FQyFVa4QFaVKiitTYiiW3frB9KYW5OWdPrqFc7FzxgB20hP4cHMlr+MBzGcLl3jnCOVOydL9mIg==",
       "dependencies": {
         "eslint-config-airbnb-base": "^15.0.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.13.0 || ^6.0.0",
-        "@typescript-eslint/parser": "^5.0.0 || ^6.0.0",
-        "eslint": "^7.32.0 || ^8.2.0",
-        "eslint-plugin-import": "^2.25.3"
+        "@typescript-eslint/eslint-plugin": "^7.0.0",
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
       }
     },
     "node_modules/eslint-config-prettier": {
@@ -38661,7 +38660,7 @@
         "@typescript-eslint/eslint-plugin": "7.13.1",
         "@typescript-eslint/parser": "7.13.1",
         "eslint-config-airbnb": "^19.0.4",
-        "eslint-config-airbnb-typescript": "^17.1.0",
+        "eslint-config-airbnb-typescript": "18.0.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-formatter-pretty": "^5.0.0",
         "eslint-import-resolver-babel-module": "^5.3.2",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -61,7 +61,7 @@
     "@typescript-eslint/eslint-plugin": "7.13.1",
     "@typescript-eslint/parser": "7.13.1",
     "eslint-config-airbnb": "^19.0.4",
-    "eslint-config-airbnb-typescript": "^17.1.0",
+    "eslint-config-airbnb-typescript": "18.0.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-formatter-pretty": "^5.0.0",
     "eslint-import-resolver-babel-module": "^5.3.2",


### PR DESCRIPTION
To update to NXv19 in DPOR, `ts-eslint` v7 is suggested but `eslint-config-airbnb-typescript `has the following peerDeps:

-     "@typescript-eslint/eslint-plugin": "^5.13.0 || ^6.0.0",
-     "@typescript-eslint/parser": "^5.0.0 || ^6.0.0",

[This new version has as peerDeps the v7](https://github.com/iamturns/eslint-config-airbnb-typescript/blob/master/package.json)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/eslint-config@11.0.1-canary.118.12776181939.0
  # or 
  yarn add @tablecheck/eslint-config@11.0.1-canary.118.12776181939.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
